### PR TITLE
Use auto page breaks

### DIFF
--- a/src/main/resources/templates/hdc_ap.html
+++ b/src/main/resources/templates/hdc_ap.html
@@ -12,10 +12,20 @@
                 content: element(footer);
             }
 
+            @top-center {
+                content: element(header);
+            }
+
             margin-top: 10%;
             margin-left: 5%;
             margin-right: 5%;
             margin-bottom: 10%;
+        }
+
+        div.header {
+            position: running(header);
+            text-align: center;
+            font-weight: bold;
         }
 
         div.footer {
@@ -187,6 +197,20 @@
 
 <body>
 
+<div class="header">
+    <table class="wide">
+        <tr>
+            <td>Name: <span class="entry">OFF_NAME</span></td>
+            <td>Prison no: <span class="entry">OFF_NOMS</span></td>
+            <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
+        </tr>
+    </table>
+</div>
+
+<div class="footer">
+    Version: VERSION_NUMBER, VERSION_DATE<br/>
+</div>
+
 <table class="wide">
     <tr>
         <td colspan="5" class="center">
@@ -255,18 +279,7 @@
     <p>At <span class="entry">REPORTING_AT</span> on <span class="entry">REPORTING_ON</span></p>
 </ol>
 
-<div class="footer">
-    Version: VERSION_NUMBER, VERSION_DATE<br/>
-</div>
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Home Detention Curfew</p>
@@ -361,21 +374,6 @@
         The installation will normally take place during standard working hours and is fully paid for by the
         supplier.
     </li>
-</ol>
-
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
 
     <li>While on Home Detention Curfew you may be liable to recall to prison if you breach the condition of this
         licence relating to the curfew.  You will be in breach of this condition if:
@@ -408,16 +406,7 @@
     </li>
 </ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Probation Supervision</p>
@@ -471,21 +460,7 @@ CONDITIONS
     <li>The Secretary of State may vary or cancel any of the above conditions, in accordance with Section 250(4) of
         the Criminal Justice Act 2003.
     </li>
-</ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>If you fail to submit yourself to a recall to custody following either a notification of the revocation of
         your licence, or remain out of contact with Probation Services for a period of six months, you may be liable to
         face a further charge of being unlawfully at large following recall under section 255ZA of the Criminal Justice
@@ -503,6 +478,8 @@ CONDITIONS
 
     <li>Your sentence expires on <span class="entry">SENT_SED</span></li>
 
+    <br/>
+    <br/>
 
     <p class="subheading">Contact Points</p>
 

--- a/src/main/resources/templates/hdc_ap_pss.html
+++ b/src/main/resources/templates/hdc_ap_pss.html
@@ -12,10 +12,20 @@
                 content: element(footer);
             }
 
+            @top-center {
+                content: element(header);
+            }
+
             margin-top: 10%;
             margin-left: 5%;
             margin-right: 5%;
             margin-bottom: 10%;
+        }
+
+        div.header {
+            position: running(header);
+            text-align: center;
+            font-weight: bold;
         }
 
         div.footer {
@@ -184,8 +194,21 @@
     </style>
 </head>
 
-
 <body>
+
+<div class="header">
+    <table class="wide">
+        <tr>
+            <td class="center">Name: <span class="entry">OFF_NAME</span></td>
+            <td class="center">Prison no: <span class="entry">OFF_NOMS</span></td>
+            <td class="center">Date of Birth: <span class="entry">OFF_DOB</span></td>
+        </tr>
+    </table>
+</div>
+
+<div class="footer">
+    Version: VERSION_NUMBER, VERSION_DATE<br/>
+</div>
 
 <table class="wide">
     <tr>
@@ -258,18 +281,7 @@
     <p>At <span class="entry">REPORTING_AT</span> on <span class="entry">REPORTING_ON</span></p>
 </ol>
 
-<div class="footer">
-    Version: VERSION_NUMBER, VERSION_DATE<br/>
-</div>
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Home Detention Curfew</p>
@@ -355,21 +367,7 @@
         midnight and 6.00am. However, the contractor may visit the curfew address between midnight and 6:00am in
         order to investigate a reported violation.
     </li>
-</ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>The monitoring equipment will usually operate via the mobile cellular network and will only need a dedicated
         telephone line to be fitted if the mobile signal is poor at the curfew address. You will be responsible for
         meeting the cost of the small amount of electricity used by the monitoring equipment at your curfew address.
@@ -418,17 +416,9 @@
     </li>
 </ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
 <br/>
+<br/>
+
 
 <p class="subheading">Licence Period</p>
 
@@ -500,16 +490,7 @@ CONDITIONS
     </li>
 </ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Post-Sentence Supervision Period</p>
@@ -554,26 +535,11 @@ CONDITIONS
             <!-- If you auto-format the file it will break the layout -->
             <!-- PSS should be at start of line -->
 <div class="pre conditions">
-PSS
+PSSCONDITIONS
 </div>
         </ol>
     </li>
 
-</ol>
-
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>The
         Secretary of State may vary or cancel any of the above conditions, in accordance with Section 256AB(4), 256D and
         256E of the Criminal Justice Act 2003.
@@ -585,6 +551,8 @@ PSS
         unpaid work or electronic location monitoring.
     </li>
 
+    <br/>
+
     <p class="subheading">Expiration Dates</p>
 
     <li>Your Home Detention Curfew expires on <span class="entry">SENT_CRD</span></li>
@@ -595,6 +563,8 @@ PSS
 
     <li>Your post-sentence supervision period expires on <span class="entry">SENT_TUSED</span></li>
 
+    <br/>
+
     <p class="subheading">Contact Points</p>
 
     <p>Monitoring Supplier: <span class="entry">MONITOR</span></p>
@@ -603,16 +573,7 @@ PSS
 
 </ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading underline">Explanatory note in respect of your licence</p>

--- a/src/main/resources/templates/hdc_pss.html
+++ b/src/main/resources/templates/hdc_pss.html
@@ -12,10 +12,20 @@
                 content: element(footer);
             }
 
+            @top-center {
+                content: element(header);
+            }
+
             margin-top: 10%;
             margin-left: 5%;
             margin-right: 5%;
             margin-bottom: 10%;
+        }
+
+        div.header {
+            position: running(header);
+            text-align: center;
+            font-weight: bold;
         }
 
         div.footer {
@@ -184,8 +194,21 @@
     </style>
 </head>
 
-
 <body>
+
+<div class="header">
+    <table class="wide">
+        <tr>
+            <td class="center">Name: <span class="entry">OFF_NAME</span></td>
+            <td class="center">Prison no: <span class="entry">OFF_NOMS</span></td>
+            <td class="center">Date of Birth: <span class="entry">OFF_DOB</span></td>
+        </tr>
+    </table>
+</div>
+
+<div class="footer">
+    Version: VERSION_NUMBER, VERSION_DATE<br/>
+</div>
 
 <table class="wide">
     <tr>
@@ -251,18 +274,7 @@
     <p>At <span class="entry">REPORTING_AT</span> on <span class="entry">REPORTING_ON</span></p>
 </ol>
 
-<div class="footer">
-    Version: VERSION_NUMBER, VERSION_DATE<br/>
-</div>
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Home Detention Curfew</p>
@@ -355,21 +367,6 @@
         It is your responsibility to ensure that there is an electricity supply available during your time on
         curfew.
     </li>
-</ol>
-
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
 
     <li>In the event of a dedicated telephone line needing to be installed you must agree to the installation at
         your curfew address for use by the supplier. The supplier will notify you of a time and a date and you must be
@@ -409,17 +406,7 @@
     </li>
 </ol>
 
-
-<div class="pagebreak"></div>
-
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Post-Sentence Supervision Period</p>
@@ -469,21 +456,6 @@ CONDITIONS
         </ol>
     </li>
 
-</ol>
-
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>The
         Secretary of State may vary or cancel any of the above conditions, in accordance with Section 256AB(4), 256D and
         256E of the Criminal Justice Act 2003.
@@ -495,6 +467,8 @@ CONDITIONS
         unpaid work or electronic location monitoring.
     </li>
 
+    <br/>
+
     <p class="subheading">Expiration Dates</p>
 
     <li>Your Home Detention Curfew expires on <span class="entry">SENT_CRD</span></li>
@@ -502,6 +476,8 @@ CONDITIONS
     <li>Your sentence expires on <span class="entry">SENT_SED</span></li>
 
     <li>Your post-sentence supervision period expires on <span class="entry">SENT_TUSED</span></li>
+
+    <br/>
 
     <p class="subheading">Contact Points</p>
 

--- a/src/main/resources/templates/hdc_u12.html
+++ b/src/main/resources/templates/hdc_u12.html
@@ -12,10 +12,20 @@
                 content: element(footer);
             }
 
+            @top-center {
+                content: element(header);
+            }
+
             margin-top: 10%;
             margin-left: 5%;
             margin-right: 5%;
             margin-bottom: 10%;
+        }
+
+        div.header {
+            position: running(header);
+            text-align: center;
+            font-weight: bold;
         }
 
         div.footer {
@@ -184,8 +194,21 @@
     </style>
 </head>
 
-
 <body>
+
+<div class="header">
+    <table class="wide">
+        <tr>
+            <td class="center">Name: <span class="entry">OFF_NAME</span></td>
+            <td class="center">Prison no: <span class="entry">OFF_NOMS</span></td>
+            <td class="center">Date of Birth: <span class="entry">OFF_DOB</span></td>
+        </tr>
+    </table>
+</div>
+
+<div class="footer">
+    Version: VERSION_NUMBER, VERSION_DATE<br/>
+</div>
 
 <table class="wide">
     <tr>
@@ -307,23 +330,7 @@
         midnight and 6.00am. However, the contractor may visit the curfew address between midnight and 6:00am in
         order to investigate a reported violation.
     </li>
-</ol>
 
-<div class="footer">
-    Version: VERSION_NUMBER, VERSION_DATE<br/>
-</div>
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>The monitoring equipment will usually operate via the mobile cellular network and will only need a dedicated
         telephone line to be fitted if the mobile signal is poor at the curfew address. You will be responsible for
         meeting the cost of the small amount of electricity used by the monitoring equipment at your curfew address.
@@ -373,23 +380,6 @@
         a new job), you must contact the Prison Service establishment from which you were released.  A contact number is
         attached at the bottom of this licence.
     </li>
-</ol>
-
-
-<div class="pagebreak"></div>
-
-
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
 
     <li>Your sentence expires on <span class="entry">SENT_SED</span></li>
 

--- a/src/main/resources/templates/hdc_yn.html
+++ b/src/main/resources/templates/hdc_yn.html
@@ -12,10 +12,20 @@
                 content: element(footer);
             }
 
+            @top-center {
+                content: element(header);
+            }
+
             margin-top: 10%;
             margin-left: 5%;
             margin-right: 5%;
             margin-bottom: 10%;
+        }
+
+        div.header {
+            position: running(header);
+            text-align: center;
+            font-weight: bold;
         }
 
         div.footer {
@@ -184,8 +194,21 @@
     </style>
 </head>
 
-
 <body>
+
+<div class="header">
+    <table class="wide">
+        <tr>
+            <td class="center">Name: <span class="entry">OFF_NAME</span></td>
+            <td class="center">Prison no: <span class="entry">OFF_NOMS</span></td>
+            <td class="center">Date of Birth: <span class="entry">OFF_DOB</span></td>
+        </tr>
+    </table>
+</div>
+
+<div class="footer">
+    Version: VERSION_NUMBER, VERSION_DATE<br/>
+</div>
 
 <table class="wide">
     <tr>
@@ -258,26 +281,10 @@
         <br/>
         <br/>
         <span class="pre entry">CURFEW_ADDRESS</span>
-        <br/>
+
         <p>Details of curfew times are shown below at paragraph 7.</p>
     </li>
-</ol>
 
-
-<div class="footer">
-    Version: VERSION_NUMBER, VERSION_DATE<br/>
-</div>
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-<ol class="continue">
     <li>On the day of your release, you will be subject to curfew at your curfew address from
         <span class="entry">CURFEW_FIRST_FROM</span> until <span class="entry">CURFEW_FIRST_UNTIL</span>. The contractor will visit you at this address
         during this time in order to fit you with the tag. You must show the contractor this copy of the licence to confirm
@@ -285,6 +292,9 @@
         of curfew the contractor will visit you to remove the tag and monitoring equipment. This will take place in the
         last two hours of your last curfew period; i.e. between 10pm and midnight.
     </li>
+
+    <div class="pagebreak"></div>
+
     <li>After your day of release, you are required to remain at your place of curfew during the following hours:</li>
     <br/>
     <table class="compact">
@@ -346,9 +356,7 @@
         midnight and 6.00am. However, the contractor may visit the curfew address between midnight and 6:00am in
         order to investigate a reported violation.
     </li>
-</ol>
 
-<ol class="continue">
     <li>The monitoring equipment will usually operate via the mobile cellular network and will only need a dedicated
         telephone line to be fitted if the mobile signal is poor at the curfew address. You will be responsible for
         meeting the cost of the small amount of electricity used by the monitoring equipment at your curfew address.
@@ -362,21 +370,7 @@
         The installation will normally take place during standard working hours and is fully paid for by the
         supplier.
     </li>
-</ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>While on Home Detention Curfew you may be liable to recall to prison if you breach the condition of this
         licence relating to the curfew.  You will be in breach of this condition if:
 
@@ -412,16 +406,7 @@
     </li>
 </ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Probation Supervision</p>
@@ -479,23 +464,6 @@ CONDITIONS
         face a further charge of being unlawfully at large following recall under section 255ZA of the Criminal Justice
         Act 2003. This could result in a fine, a sentence of up to two years’ imprisonment, or both.
     </li>
-</ol>
-
-
-
-<div class="pagebreak"></div>
-
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
 
     <li>If you fail to comply with any requirement of your supervision (set out in paragraphs 4, 16 and 17 above) under
     section 256C of the Criminal Justice Act 2003 you will be liable to be summoned to appear before a court. The court
@@ -505,13 +473,13 @@ CONDITIONS
     <li>Your sentence expires on <span class="entry">SENT_SED</span></li>
 </ol>
 
+<br/>
 
 <p class="subheading">Contact Points</p>
 
 <p>Monitoring Supplier: <span class="entry">MONITOR</span></p>
 
 <p>Releasing establishment: <span class="entry">EST_PHONE</span></p>
-
 
 <br/>
 <br/>
@@ -545,9 +513,6 @@ CONDITIONS
         <td>Date:</td>
     </tr>
 </table>
-
-
-
 
 </body>
 </html>

--- a/src/main/resources/templates/vary_hdc_ap.html
+++ b/src/main/resources/templates/vary_hdc_ap.html
@@ -12,10 +12,20 @@
                 content: element(footer);
             }
 
+            @top-center {
+                content: element(header);
+            }
+
             margin-top: 10%;
             margin-left: 5%;
             margin-right: 5%;
             margin-bottom: 10%;
+        }
+
+        div.header {
+            position: running(header);
+            text-align: center;
+            font-weight: bold;
         }
 
         div.footer {
@@ -241,18 +251,6 @@
     </li>
 </ol>
 
-<div class="footer">
-    Version: VERSION_NUMBER, VERSION_DATE<br/>
-</div>
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
 <br/>
 
 <p class="subheading">Home Detention Curfew</p>
@@ -346,21 +344,6 @@
         The installation will normally take place during standard working hours and is fully paid for by the
         supplier.
     </li>
-</ol>
-
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
 
     <li>While on Home Detention Curfew you may be liable to recall to prison if you breach the condition of this
         licence relating to the curfew.  You will be in breach of this condition if:
@@ -393,16 +376,7 @@
     </li>
 </ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Probation Supervision</p>
@@ -456,21 +430,7 @@ CONDITIONS
     <li>The Secretary of State may vary or cancel any of the above conditions, in accordance with Section 250(4) of
         the Criminal Justice Act 2003.
     </li>
-</ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>If you fail to submit yourself to a recall to custody following either a notification of the revocation of
         your licence, or remain out of contact with Probation Services for a period of six months, you may be liable to
         face a further charge of being unlawfully at large following recall under section 255ZA of the Criminal Justice
@@ -496,7 +456,6 @@ CONDITIONS
     <p>Releasing establishment: <span class="entry">EST_PHONE</span></p>
 
 </ol>
-
 
 <br/>
 <br/>

--- a/src/main/resources/templates/vary_hdc_ap_pss.html
+++ b/src/main/resources/templates/vary_hdc_ap_pss.html
@@ -12,10 +12,20 @@
                 content: element(footer);
             }
 
+            @top-center {
+                content: element(header);
+            }
+
             margin-top: 10%;
             margin-left: 5%;
             margin-right: 5%;
             margin-bottom: 10%;
+        }
+
+        div.header {
+            position: running(header);
+            text-align: center;
+            font-weight: bold;
         }
 
         div.footer {
@@ -243,18 +253,7 @@
     <li>Your post-sentence supervision period commences on <span class="entry">SENT_LED</span></li>
 </ol>
 
-<div class="footer">
-    Version: VERSION_NUMBER, VERSION_DATE<br/>
-</div>
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Home Detention Curfew</p>
@@ -338,21 +337,7 @@
         midnight and 6.00am. However, the contractor may visit the curfew address between midnight and 6:00am in
         order to investigate a reported violation.
     </li>
-</ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>The monitoring equipment will usually operate via the mobile cellular network and will only need a dedicated
         telephone line to be fitted if the mobile signal is poor at the curfew address. You will be responsible for
         meeting the cost of the small amount of electricity used by the monitoring equipment at your curfew address.
@@ -401,16 +386,7 @@
     </li>
 </ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Licence Period</p>
@@ -483,16 +459,7 @@ CONDITIONS
     </li>
 </ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Post-Sentence Supervision Period</p>
@@ -542,21 +509,6 @@ PSS
         </ol>
     </li>
 
-</ol>
-
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>The
         Secretary of State may vary or cancel any of the above conditions, in accordance with Section 256AB(4), 256D and
         256E of the Criminal Justice Act 2003.
@@ -586,16 +538,6 @@ PSS
 
 </ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
 <br/>
 
 <p class="subheading underline">Explanatory note in respect of your licence</p>

--- a/src/main/resources/templates/vary_hdc_pss.html
+++ b/src/main/resources/templates/vary_hdc_pss.html
@@ -12,10 +12,20 @@
                 content: element(footer);
             }
 
+            @top-center {
+                content: element(header);
+            }
+
             margin-top: 10%;
             margin-left: 5%;
             margin-right: 5%;
             margin-bottom: 10%;
+        }
+
+        div.header {
+            position: running(header);
+            text-align: center;
+            font-weight: bold;
         }
 
         div.footer {
@@ -236,18 +246,7 @@
     <li>Your post-sentence supervision period expires on<span class="entry">SENT_TUSED</span></li>
 </ol>
 
-<div class="footer">
-    Version: VERSION_NUMBER, VERSION_DATE<br/>
-</div>
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Home Detention Curfew</p>
@@ -340,21 +339,6 @@
         It is your responsibility to ensure that there is an electricity supply available during your time on
         curfew.
     </li>
-</ol>
-
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
 
     <li>In the event of a dedicated telephone line needing to be installed you must agree to the installation at
         your curfew address for use by the supplier. The supplier will notify you of a time and a date and you must be
@@ -394,17 +378,7 @@
     </li>
 </ol>
 
-
-<div class="pagebreak"></div>
-
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Post-Sentence Supervision Period</p>
@@ -454,21 +428,6 @@ CONDITIONS
         </ol>
     </li>
 
-</ol>
-
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>The
         Secretary of State may vary or cancel any of the above conditions, in accordance with Section 256AB(4), 256D and
         256E of the Criminal Justice Act 2003.

--- a/src/main/resources/templates/vary_hdc_u12.html
+++ b/src/main/resources/templates/vary_hdc_u12.html
@@ -12,10 +12,20 @@
                 content: element(footer);
             }
 
+            @top-center {
+                content: element(header);
+            }
+
             margin-top: 10%;
             margin-left: 5%;
             margin-right: 5%;
             margin-bottom: 10%;
+        }
+
+        div.header {
+            position: running(header);
+            text-align: center;
+            font-weight: bold;
         }
 
         div.footer {
@@ -300,23 +310,7 @@
         midnight and 6.00am. However, the contractor may visit the curfew address between midnight and 6:00am in
         order to investigate a reported violation.
     </li>
-</ol>
 
-<div class="footer">
-    Version: VERSION_NUMBER, VERSION_DATE<br/>
-</div>
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>The monitoring equipment will usually operate via the mobile cellular network and will only need a dedicated
         telephone line to be fitted if the mobile signal is poor at the curfew address. You will be responsible for
         meeting the cost of the small amount of electricity used by the monitoring equipment at your curfew address.
@@ -366,23 +360,6 @@
         a new job), you must contact the Prison Service establishment from which you were released.  A contact number is
         attached at the bottom of this licence.
     </li>
-</ol>
-
-
-<div class="pagebreak"></div>
-
-
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
 
     <li>Your sentence expires on <span class="entry">SENT_SED</span></li>
 

--- a/src/main/resources/templates/vary_hdc_yn.html
+++ b/src/main/resources/templates/vary_hdc_yn.html
@@ -12,10 +12,20 @@
                 content: element(footer);
             }
 
+            @top-center {
+                content: element(header);
+            }
+
             margin-top: 10%;
             margin-left: 5%;
             margin-right: 5%;
             margin-bottom: 10%;
+        }
+
+        div.header {
+            position: running(header);
+            text-align: center;
+            font-weight: bold;
         }
 
         div.footer {
@@ -251,23 +261,7 @@
         <br/>
         <p>Details of curfew times are shown below at paragraph 7.</p>
     </li>
-</ol>
 
-
-<div class="footer">
-    Version: VERSION_NUMBER, VERSION_DATE<br/>
-</div>
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-<ol class="continue">
     <li>On the day of your release, you will be subject to curfew at your curfew address.
         The contractor will visit you at this address
         during this time in order to fit you with the tag. You must show the contractor this copy of the licence to confirm
@@ -336,9 +330,7 @@
         midnight and 6.00am. However, the contractor may visit the curfew address between midnight and 6:00am in
         order to investigate a reported violation.
     </li>
-</ol>
 
-<ol class="continue">
     <li>The monitoring equipment will usually operate via the mobile cellular network and will only need a dedicated
         telephone line to be fitted if the mobile signal is poor at the curfew address. You will be responsible for
         meeting the cost of the small amount of electricity used by the monitoring equipment at your curfew address.
@@ -352,21 +344,7 @@
         The installation will normally take place during standard working hours and is fully paid for by the
         supplier.
     </li>
-</ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
     <li>While on Home Detention Curfew you may be liable to recall to prison if you breach the condition of this
         licence relating to the curfew.  You will be in breach of this condition if:
 
@@ -402,16 +380,7 @@
     </li>
 </ol>
 
-
-<div class="pagebreak"></div>
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
+<br/>
 <br/>
 
 <p class="subheading">Probation Supervision</p>
@@ -469,23 +438,6 @@ CONDITIONS
         face a further charge of being unlawfully at large following recall under section 255ZA of the Criminal Justice
         Act 2003. This could result in a fine, a sentence of up to two years’ imprisonment, or both.
     </li>
-</ol>
-
-
-
-<div class="pagebreak"></div>
-
-
-<table class="wide noLeftPad">
-    <tr>
-        <td>Name: <span class="entry">OFF_NAME</span></td>
-        <td>Prison no: <span class="entry">OFF_NOMS</span></td>
-        <td>Date of Birth: <span class="entry">OFF_DOB</span></td>
-    </tr>
-</table>
-<br/>
-
-<ol class="continue">
 
     <li>If you fail to comply with any requirement of your supervision (set out in paragraphs 4, 16 and 17 above) under
     section 256C of the Criminal Justice Act 2003 you will be liable to be summoned to appear before a court. The court
@@ -495,7 +447,7 @@ CONDITIONS
     <li>Your sentence expires on <span class="entry">SENT_SED</span></li>
 </ol>
 
-
+<br/>
 <p class="subheading">Contact Points</p>
 
 <p>Monitoring Supplier: <span class="entry">MONITOR</span></p>


### PR DESCRIPTION
Remove manual page breaks to save empty space in the PDF now that we don't have to replicate the exact page layout of the old paper licences.

Use a running header instead of a manual header so that it still appears on every page with auto page breaks.

Change a placeholder name to avoid conflict with actual content text.

Some minor spacing adjustments between sections.

Repeat for 10 templates.